### PR TITLE
docs: Remove traces of AB3 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,5 @@
 
 This app helps students find more-knowledge-others(MKOs) that they already know, and have the contacts for, by filtering their contacts by modules. ModContact allows for discovery of new MKOs (assuming this does not violate the constraints for the evolve direction).
 
-This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).
-
-- This is **a sample project for Software Engineering (SE) students**.<br>
-  Example usages:
-  - as a starting point of a course project (as opposed to writing everything from scratch)
-  - as a case study
-- The project simulates an ongoing software project for a desktop application (called _AddressBook_) used for managing contact details.
-  - It is **written in OOP fashion**. It provides a **reasonably well-written** code base **bigger** (around 6 KLoC) than what students usually write in beginner-level SE modules, without being overwhelmingly big.
-  - It comes with a **reasonable level of user and developer documentation**.
-- It is named `AddressBook Level 3` (`AB3` for short) because it was initially created as a part of a series of `AddressBook` projects (`Level 1`, `Level 2`, `Level 3` ...).
-- For the detailed documentation of this project, see the **[Address Book Product Website](https://se-education.org/addressbook-level3)**.
-- This project is a **part of the se-education.org** initiative. If you would like to contribute code to this project, see [se-education.org](https://se-education.org#https://se-education.org/#contributing) for more info.
+# Acknowlegement
+This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org)


### PR DESCRIPTION
This commit removes the traces of AB3 in README that was pointed out in the cs2103 tracker.