### PR TITLE
feat: Introduce `add_module` command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Student;
 
 /**
@@ -47,5 +49,4 @@ public class Messages {
         student.getTags().forEach(builder::append);
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,8 +5,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
-import seedu.address.model.module.Module;
-import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Student;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
+
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -7,11 +13,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Student;
-
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
 
 /**
  * Adds a student to the address book.

--- a/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.student.Student;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Adds a student to the address book.
+ */
+public class AddStudentModuleCommand extends Command {
+
+    public static final String COMMAND_WORD = "add_module";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to the student in the address book. "
+            + "Parameters: "
+            + PREFIX_STUDENT_ID + "STUDENT ID"
+            + PREFIX_MODULE_CODE + "MODULE CODE";
+
+    public static final String MESSAGE_SUCCESS = "New module %1$s added to student: %2$s";
+    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the student's contact in address book";
+
+    private final Index index;
+    private final ModuleCode moduleCode;
+
+    /**
+     * Creates an AddStudentModuleCommand to add the specified {@code Module} to {@code Student}
+     */
+    public AddStudentModuleCommand(Index index, ModuleCode moduleCode) {
+        requireNonNull(index);
+        requireNonNull(moduleCode);
+        this.index = index;
+        this.moduleCode = moduleCode;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Student> lastShownList = model.getFilteredStudentList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        }
+
+        Student studentToModify = lastShownList.get(index.getZeroBased());
+
+        if (model.doesStudentHaveModule(studentToModify, moduleCode)) {
+            throw new CommandException(MESSAGE_DUPLICATE_MODULE);
+        }
+
+        model.addModuleToStudent(moduleCode, studentToModify);
+
+        return new CommandResult(
+                String.format(
+                        MESSAGE_SUCCESS,
+                        moduleCode.getCode(),
+                        Messages.format(studentToModify)
+                )
+        );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddStudentModuleCommand)) {
+            return false;
+        }
+
+        AddStudentModuleCommand otherAddCommand = (AddStudentModuleCommand) other;
+        return index.equals(otherAddCommand.index) && moduleCode.equals(otherAddCommand.moduleCode);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("student index to add module to", index)
+                .add("module to add to student", moduleCode)
+                .toString();
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
@@ -5,7 +5,6 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Student;
 

--- a/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentModuleCommand.java
@@ -27,7 +27,8 @@ public class AddStudentModuleCommand extends Command {
             + PREFIX_MODULE_CODE + "MODULE CODE";
 
     public static final String MESSAGE_SUCCESS = "New module %1$s added to student: %2$s";
-    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the student's contact in address book";
+    public static final String MESSAGE_DUPLICATE_MODULE =
+            "This module already exists in the student's contact in address book";
 
     private final Index index;
     private final ModuleCode moduleCode;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -142,7 +142,7 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
-        private List<ModuleCode> modules;
+        private List<ModuleCode> modules = new ArrayList<>();
 
         public EditStudentDescriptor() {}
 
@@ -159,7 +159,7 @@ public class EditCommand extends Command {
             setModules(toCopy.modules);
         }
 
-        private void setModules(List<ModuleCode> modules) {
+        public void setModules(List<ModuleCode> modules) {
             this.modules = new ArrayList<>(modules);
         }
 
@@ -239,7 +239,8 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditStudentDescriptor.phone)
                     && Objects.equals(email, otherEditStudentDescriptor.email)
                     && Objects.equals(address, otherEditStudentDescriptor.address)
-                    && Objects.equals(tags, otherEditStudentDescriptor.tags);
+                    && Objects.equals(tags, otherEditStudentDescriptor.tags)
+                    && Objects.equals(modules, otherEditStudentDescriptor.modules);
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,12 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -21,6 +16,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Address;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -100,8 +96,9 @@ public class EditCommand extends Command {
         Email updatedEmail = editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail());
         Address updatedAddress = editStudentDescriptor.getAddress().orElse(studentToEdit.getAddress());
         Set<Tag> updatedTags = editStudentDescriptor.getTags().orElse(studentToEdit.getTags());
+        List<ModuleCode> updatedModules = editStudentDescriptor.getModules().orElse(studentToEdit.getModules());
 
-        return new Student(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Student(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedModules);
     }
 
     @Override
@@ -139,6 +136,8 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
+        private List<ModuleCode> modules;
+
         public EditStudentDescriptor() {}
 
         /**
@@ -151,6 +150,11 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setModules(toCopy.modules);
+        }
+
+        private void setModules(List<ModuleCode> modules) {
+            this.modules = new ArrayList<>(modules);
         }
 
         /**
@@ -174,6 +178,10 @@ public class EditCommand extends Command {
 
         public Optional<Phone> getPhone() {
             return Optional.ofNullable(phone);
+        }
+
+        public Optional<List<ModuleCode>> getModules() {
+            return (modules != null) ? Optional.of(modules) : Optional.empty();
         }
 
         public void setEmail(Email email) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,7 +8,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -45,7 +46,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Student student = new Student(name, phone, email, address, tagList);
+        Student student = new Student(name, phone, email, address, tagList, new ArrayList<>());
 
         return new AddCommand(student);
     }

--- a/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
@@ -26,7 +26,10 @@ public class AddStudentModuleCommandParser implements Parser<AddStudentModuleCom
                 ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_ID, PREFIX_MODULE_CODE);
         if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID, PREFIX_MODULE_CODE)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddStudentModuleCommand.MESSAGE_USAGE));
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddStudentModuleCommand.MESSAGE_USAGE
+            ));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENT_ID, PREFIX_MODULE_CODE);

--- a/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddStudentModuleCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.student.Address;
+import seedu.address.model.student.Email;
+import seedu.address.model.student.Name;
+import seedu.address.model.student.Phone;
+import seedu.address.model.student.Student;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddStudentModuleCommandParser implements Parser<AddStudentModuleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddStudentModuleCommand parse(String args) throws ParseException {
+       ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_ID, PREFIX_MODULE_CODE);
+        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID, PREFIX_MODULE_CODE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddStudentModuleCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENT_ID, PREFIX_MODULE_CODE);
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_ID).get());
+        ModuleCode moduleCode = ParserUtil.parseModule(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+
+        return new AddStudentModuleCommand(index, moduleCode);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
@@ -4,21 +4,12 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 
-import java.util.ArrayList;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddStudentModuleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.ModuleCode;
-import seedu.address.model.student.Address;
-import seedu.address.model.student.Email;
-import seedu.address.model.student.Name;
-import seedu.address.model.student.Phone;
-import seedu.address.model.student.Student;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddCommand object

--- a/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStudentModuleCommandParser.java
@@ -22,7 +22,7 @@ public class AddStudentModuleCommandParser implements Parser<AddStudentModuleCom
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddStudentModuleCommand parse(String args) throws ParseException {
-       ArgumentMultimap argMultimap =
+        ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_ID, PREFIX_MODULE_CODE);
         if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID, PREFIX_MODULE_CODE)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,7 +8,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddStudentModuleCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,15 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -55,6 +47,9 @@ public class AddressBookParser {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+        case AddStudentModuleCommand.COMMAND_WORD:
+            return new AddStudentModuleCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,4 +12,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    public static final Prefix PREFIX_MODULE_CODE = new Prefix("m/");
+
+    public static final Prefix PREFIX_STUDENT_ID = new Prefix("i/");
+
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Address;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -120,5 +121,9 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    public static ModuleCode parseModule(String s) {
+        return new ModuleCode(s);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,12 +2,10 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
 import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.UniqueStudentList;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,10 +2,13 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
 import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.UniqueStudentList;
 
@@ -95,6 +98,18 @@ public class AddressBook implements ReadOnlyAddressBook {
         students.remove(key);
     }
 
+    public void addModuleToStudent(ModuleCode m, Student s) {
+        requireNonNull(m);
+        requireNonNull(s);
+        for (Student candidate : students) {
+            if (candidate.equals(s) && !candidate.hasModule(m)) {
+                Student editedStudent = candidate.copy();
+                editedStudent.getModules().add(m);
+                students.setStudent(candidate, editedStudent);
+                return;
+            }
+        }
+    }
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -96,6 +96,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         students.remove(key);
     }
 
+    /**
+     * Adds a module to a student in the address book.
+     *
+     * @param m The module code to be added.
+     * @param s The student to whom the module is to be added.
+     */
     public void addModuleToStudent(ModuleCode m, Student s) {
         requireNonNull(m);
         requireNonNull(s);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleMap;
 import seedu.address.model.student.Student;
 
@@ -88,4 +89,19 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredStudentList(Predicate<Student> predicate);
+
+    /**
+     * Checks if student `s` has moduleCode `m`
+     * @param s Student
+     * @param m Module
+     * @return Whether student has that module or not
+     */
+    boolean doesStudentHaveModule(Student s, ModuleCode m);
+
+    /**
+     * Adds module to the specified student
+     * @param m Module to add
+     * @param s Student to add module to
+     */
+    void addModuleToStudent(ModuleCode m, Student s);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -147,7 +147,7 @@ public class ModelManager implements Model {
 
     @Override
     public void addModuleToStudent(ModuleCode m, Student s) {
-        addressBook.addModuleToStudent(m,s);
+        addressBook.addModuleToStudent(m, s);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleMap;
 import seedu.address.model.student.Student;
 
@@ -120,6 +122,8 @@ public class ModelManager implements Model {
         addressBook.setStudent(target, editedStudent);
     }
 
+
+
     //=========== Filtered Student List Accessors =============================================================
 
     /**
@@ -135,6 +139,16 @@ public class ModelManager implements Model {
     public void updateFilteredStudentList(Predicate<Student> predicate) {
         requireNonNull(predicate);
         filteredStudents.setPredicate(predicate);
+    }
+
+    @Override
+    public boolean doesStudentHaveModule(Student s, ModuleCode m) {
+        return s.hasModule(m);
+    }
+
+    @Override
+    public void addModuleToStudent(ModuleCode m, Student s) {
+        addressBook.addModuleToStudent(m,s);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleMap;
 import seedu.address.model.student.Student;

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -2,13 +2,12 @@ package seedu.address.model.student;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.tag.Tag;
+
+import java.util.*;
 
 /**
  * Represents a Student in the address book.
@@ -25,15 +24,18 @@ public class Student {
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
 
+    private final List<ModuleCode> modules = new ArrayList<>();
+
     /**
      * Every field must be present and not null.
      */
-    public Student(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+    public Student(Name name, Phone phone, Email email, Address address, Set<Tag> tags, List<ModuleCode> modules) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.modules.addAll(modules);
         this.tags.addAll(tags);
     }
 
@@ -61,6 +63,21 @@ public class Student {
         return Collections.unmodifiableSet(tags);
     }
 
+    /**
+     * Returns list of modules student is taking
+     */
+    public List<ModuleCode> getModules() {
+        return modules;
+    }
+
+    /**
+     * Checks if module `m` is held within the student
+     * @param m Module to check
+     * @return true if module is taken by student
+     */
+    public boolean hasModule(ModuleCode m) {
+        return modules.contains(m);
+    }
     /**
      * Returns true if both students have the same name.
      * This defines a weaker notion of equality between two students.
@@ -94,13 +111,26 @@ public class Student {
                 && phone.equals(otherStudent.phone)
                 && email.equals(otherStudent.email)
                 && address.equals(otherStudent.address)
-                && tags.equals(otherStudent.tags);
+                && tags.equals(otherStudent.tags)
+                && modules.equals(otherStudent.modules);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, modules);
+    }
+
+    public Student copy() {
+        Student s1 = new Student(
+                this.name,
+                this.phone,
+                this.email,
+                this.address,
+                this.tags,
+                this.modules
+        );
+        return s1;
     }
 
     @Override
@@ -111,6 +141,7 @@ public class Student {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("modules", modules)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -2,11 +2,16 @@ package seedu.address.model.student;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.tag.Tag;
-
-import java.util.*;
 
 /**
  * Represents a Student in the address book.

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -3,7 +3,6 @@ package seedu.address.model.student;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.tag.Tag;
 
@@ -121,8 +120,12 @@ public class Student {
         return Objects.hash(name, phone, email, address, tags, modules);
     }
 
+    /**
+     * Returns a shallow copy of a student instance.
+     * @return a shallow copy of a student instance
+     */
     public Student copy() {
-        Student s1 = new Student(
+        return new Student(
                 this.name,
                 this.phone,
                 this.email,
@@ -130,7 +133,6 @@ public class Student {
                 this.tags,
                 this.modules
         );
-        return s1;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.model.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -21,22 +22,22 @@ public class SampleDataUtil {
         return new Student[] {
             new Student(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+                getTagSet("friends"),  new ArrayList<>()),
             new Student(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"), new ArrayList<>()),
             new Student(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"), new ArrayList<>()),
             new Student(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
+                getTagSet("family"), new ArrayList<>()),
             new Student(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
+                getTagSet("classmates"), new ArrayList<>()),
             new Student(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"), new ArrayList<>())
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -22,7 +22,7 @@ public class SampleDataUtil {
         return new Student[] {
             new Student(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"),  new ArrayList<>()),
+                getTagSet("friends"), new ArrayList<>()),
             new Student(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                 getTagSet("colleagues", "friends"), new ArrayList<>()),

--- a/src/main/java/seedu/address/storage/JsonAdaptedModuleCode.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModuleCode.java
@@ -1,0 +1,47 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.module.ModuleCode;
+
+/**
+ * Jackson-friendly version of {@link ModuleCode}.
+ */
+class JsonAdaptedModuleCode {
+
+    private final String moduleCode;
+
+    /**
+     * Constructs a {@code moduleCode} with the given {@code moduleCode}.
+     */
+    @JsonCreator
+    public JsonAdaptedModuleCode(String moduleCode) {
+        this.moduleCode = moduleCode;
+    }
+
+    /**
+     * Converts a given {@code Tag} into this class for Jackson use.
+     */
+    public JsonAdaptedModuleCode(ModuleCode source) {
+        moduleCode = source.getCode();
+    }
+
+    @JsonValue
+    public String getModuleCode() {
+        return moduleCode;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted moduleCode object into the model's {@code ModuleCode} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted moduleCode.
+     */
+    public ModuleCode toModelType() throws IllegalValueException {
+        if (!ModuleCode.isValidCode(moduleCode)) {
+            throw new IllegalValueException(ModuleCode.MESSAGE_CONSTRAINTS);
+        }
+        return new ModuleCode(moduleCode);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedModuleCode.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModuleCode.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.module.ModuleCode;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
@@ -1,6 +1,9 @@
 package seedu.address.storage;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
@@ -1,15 +1,14 @@
 package seedu.address.storage;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Address;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -28,6 +27,7 @@ class JsonAdaptedStudent {
     private final String phone;
     private final String email;
     private final String address;
+    private final List<JsonAdaptedModuleCode> moduleCodes = new ArrayList<>();
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -36,15 +36,21 @@ class JsonAdaptedStudent {
     @JsonCreator
     public JsonAdaptedStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("tags") List<JsonAdaptedTag> tags,
+                              @JsonProperty("modules") List<JsonAdaptedModuleCode> moduleCodes) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        if (moduleCodes != null) {
+            this.moduleCodes.addAll(moduleCodes);
+        }
+
         if (tags != null) {
             this.tags.addAll(tags);
         }
     }
+
 
     /**
      * Converts a given {@code Student} into this class for Jackson use.
@@ -56,6 +62,11 @@ class JsonAdaptedStudent {
         address = source.getAddress().value;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+        moduleCodes.addAll(source
+                .getModules()
+                .stream()
+                .map(JsonAdaptedModuleCode::new)
                 .collect(Collectors.toList()));
     }
 
@@ -103,7 +114,13 @@ class JsonAdaptedStudent {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(studentTags);
-        return new Student(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+
+        final List<ModuleCode> modelModuleCodes = new ArrayList<>();
+        for (JsonAdaptedModuleCode moduleCode : moduleCodes) {
+            modelModuleCodes.add(moduleCode.toModelType());
+        }
+
+        return new Student(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelModuleCodes);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Address;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleMap;
 import seedu.address.model.student.Student;
 import seedu.address.testutil.StudentBuilder;
@@ -162,6 +163,18 @@ public class AddCommandTest {
         @Override
         public void updateFilteredStudentList(Predicate<Student> predicate) {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean doesStudentHaveModule(Student s, ModuleCode m) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'doesStudentHaveModule'");
+        }
+
+        @Override
+        public void addModuleToStudent(ModuleCode m, Student s) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'addModuleToStudent'");
         }
     }
 

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -93,7 +93,8 @@ public class StudentTest {
     @Test
     public void toStringMethod() {
         String expected = Student.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
+                + ", modules=" + ALICE.getModules() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -43,14 +43,30 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+                new JsonAdaptedStudent(
+                    INVALID_NAME,
+                    VALID_PHONE,
+                    VALID_EMAIL,
+                    VALID_ADDRESS,
+                    VALID_TAGS,
+                    VALID_MODULES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+        assertThrows(
+            IllegalValueException.class,
+            expectedMessage,
+            student::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(
+            null,
+            VALID_PHONE,
+            VALID_EMAIL,
+            VALID_ADDRESS,
+            VALID_TAGS,
+            VALID_MODULES
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -58,14 +74,27 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+            new JsonAdaptedStudent(VALID_NAME,
+                INVALID_PHONE,
+                VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_TAGS,
+                VALID_MODULES
+            );
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(
+            VALID_NAME,
+            null,
+            VALID_EMAIL,
+            VALID_ADDRESS,
+            VALID_TAGS,
+            VALID_MODULES
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -73,14 +102,28 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+            new JsonAdaptedStudent(
+                VALID_NAME,
+                VALID_PHONE,
+                INVALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_TAGS,
+                VALID_MODULES
+            );
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(
+            VALID_NAME,
+            VALID_PHONE,
+            null,
+            VALID_ADDRESS,
+            VALID_TAGS,
+            VALID_MODULES
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -88,14 +131,28 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_MODULES);
+                new JsonAdaptedStudent(
+                    VALID_NAME,
+                    VALID_PHONE,
+                    VALID_EMAIL,
+                    INVALID_ADDRESS,
+                    VALID_TAGS,
+                    VALID_MODULES
+                );
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_MODULES);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(
+            VALID_NAME,
+            VALID_PHONE,
+            VALID_EMAIL,
+            null,
+            VALID_TAGS,
+            VALID_MODULES
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -24,7 +24,7 @@ public class JsonAdaptedStudentTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
-    private static final List<String> VALID_MODULES = new ArrayList<>();
+    private static final List<JsonAdaptedModuleCode> VALID_MODULES = new ArrayList<>();
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -24,6 +24,8 @@ public class JsonAdaptedStudentTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
+    private static final List<String> VALID_MODULES = new ArrayList<>();
+
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
@@ -41,14 +43,14 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -56,14 +58,14 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -71,14 +73,14 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -86,14 +88,14 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_MODULES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_MODULES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -103,7 +105,7 @@ public class JsonAdaptedStudentTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_MODULES);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/EditStudentDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditStudentDescriptorBuilder.java
@@ -37,6 +37,7 @@ public class EditStudentDescriptorBuilder {
         descriptor.setEmail(student.getEmail());
         descriptor.setAddress(student.getAddress());
         descriptor.setTags(student.getTags());
+        descriptor.setModules(student.getModules());
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/address/testutil/StudentBuilder.java
@@ -1,8 +1,11 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Address;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -26,6 +29,7 @@ public class StudentBuilder {
     private Email email;
     private Address address;
     private Set<Tag> tags;
+    private List<ModuleCode> modules;
 
     /**
      * Creates a {@code StudentBuilder} with the default details.
@@ -36,6 +40,7 @@ public class StudentBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        modules = new ArrayList<>();
     }
 
     /**
@@ -47,6 +52,7 @@ public class StudentBuilder {
         email = studentToCopy.getEmail();
         address = studentToCopy.getAddress();
         tags = new HashSet<>(studentToCopy.getTags());
+        modules = new ArrayList<>(studentToCopy.getModules());
     }
 
     /**
@@ -89,8 +95,16 @@ public class StudentBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code modules} of the {@code Student} that we are building.
+     */
+    public StudentBuilder withModules(List<ModuleCode> modules) {
+        this.modules = new ArrayList<>(modules);
+        return this;
+    }
+
     public Student build() {
-        return new Student(name, phone, email, address, tags);
+        return new Student(name, phone, email, address, tags, modules);
     }
 
 }


### PR DESCRIPTION
This `add_module` command introduces new prefixes, new classes (i.e `AddStudentModuleCommand/Parser`, etc.).

The example of the `add_module` command is `add_module i/<INDEX> m/<MODULE_CODE>`

In the parser layer, I've added a `AddStudentModuleCommandParser` that craps out a `AddStudentModuleCommand`. It then executes and deals with the `Student` model.

model: `Student` now supports a list of `modules` which are `ModuleCode`.

For now, we are storing a list of `ModuleCode` instead of `Module` in each Student model. This is because the ability to synchronize the state of Modules in `ModuleMap` and `Student` will be tough to keep track off, thus I've resorted to using `ModuleCode` instead.

For the storage layer, I've also added a `JsonAdaptedModuleCode`. I had to add this because there was some finicky issue with saving a List<String> within a `.json` file so I created the adapter and it fixed the issue. If anyone knows how to do it without creating that adapter feel free to correct this!
---
Edit by @AdityaB4 at 8:20pm SGT on 21/3/2024:
Resolves #21 