### PR TITLE
Remove unnecessary function in ModuleMapStorage

### DIFF
--- a/src/main/java/seedu/address/storage/JsonModuleMapStorage.java
+++ b/src/main/java/seedu/address/storage/JsonModuleMapStorage.java
@@ -26,11 +26,6 @@ public class JsonModuleMapStorage implements ModuleMapStorage {
     public JsonModuleMapStorage() {}
 
     @Override
-    public Path getModuleFilePath() {
-        return null;
-    }
-
-    @Override
     public ModuleMap readModuleMap() {
         requireNonNull(filePath);
 

--- a/src/main/java/seedu/address/storage/ModuleMapStorage.java
+++ b/src/main/java/seedu/address/storage/ModuleMapStorage.java
@@ -1,14 +1,10 @@
 package seedu.address.storage;
 
-import java.nio.file.Path;
-
 import seedu.address.model.module.ModuleMap;
 
 /**
  * Represents a storage for {@link seedu.address.model.module.ModuleMap}.
  */
 public interface ModuleMapStorage {
-    Path getModuleFilePath();
-
     ModuleMap readModuleMap();
 }

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -31,9 +31,6 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage, ModuleMap
     void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException;
 
     @Override
-    Path getModuleFilePath();
-
-    @Override
     ModuleMap readModuleMap();
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -83,13 +83,8 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public Path getModuleFilePath() {
-        return moduleMapStorage.getModuleFilePath();
-    }
-
-    @Override
     public ModuleMap readModuleMap() {
-        logger.fine("Attempting to read data from file: " + moduleMapStorage.getModuleFilePath());
+        logger.fine("Attempting to read data from module map");
         return moduleMapStorage.readModuleMap();
     }
 }


### PR DESCRIPTION
Removes the unnecessary getPath function from moduleMapStorage. This isn't used as the module mappings are embedded in the jar file in JSON form. 