### PR TITLE
feat: Add `find_free_time` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.student.IsFreePredicate;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
 /**
  * Finds and lists all students in address book who is free in the specified timings.

--- a/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -19,7 +18,8 @@ public class FindFreeTimeCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Finds all students who are free in the time–range specified"
             + "and displays them as a list with index numbers.\n"
-            + "Example: " + COMMAND_WORD + ' ' + PREFIX_START_TIME + "0230" + ' ' + PREFIX_END_TIME + "0330";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_START_TIME + "0230" + " " + PREFIX_END_TIME + "0330"
+            + " " + PREFIX_DAY + "Wed";
 
     private final IsFreePredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
@@ -19,8 +19,7 @@ public class FindFreeTimeCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Finds all students who are free in the time–range specified"
             + "and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + PREFIX_START_TIME + "0230" + PREFIX_END_TIME + "0330";
+            + "Example: " + COMMAND_WORD + ' ' + PREFIX_START_TIME + "0230" + ' ' + PREFIX_END_TIME + "0330";
 
     private final IsFreePredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;

--- a/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindFreeTimeCommand.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.student.IsFreePredicate;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+
+/**
+ * Finds and lists all students in address book who is free in the specified timings.
+ */
+public class FindFreeTimeCommand extends Command {
+
+    public static final String COMMAND_WORD = "find_free_time";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all students who are free in the time–range specified"
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + PREFIX_START_TIME + "0230" + PREFIX_END_TIME + "0330";
+
+    private final IsFreePredicate predicate;
+
+    public FindFreeTimeCommand(IsFreePredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredStudentList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW, model.getFilteredStudentList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindFreeTimeCommand)) {
+            return false;
+        }
+
+        FindFreeTimeCommand otherFindCommand = (FindFreeTimeCommand) other;
+        return predicate.equals(otherFindCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.DeleteStudentModuleCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindFreeTimeCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.module.ListModulesCommand;
@@ -82,6 +83,8 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+        case FindFreeTimeCommand.COMMAND_WORD:
+            return new FindFreeTimeCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindFreeTimeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Day;
 import seedu.address.model.module.Timing;
 import seedu.address.model.student.IsFreePredicate;
 
@@ -24,19 +24,20 @@ public class FindFreeTimeCommandParser implements Parser<FindFreeTimeCommand> {
     public FindFreeTimeCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
-                        args, PREFIX_START_TIME, PREFIX_END_TIME);
+                        args, PREFIX_START_TIME, PREFIX_END_TIME, PREFIX_DAY);
         if (!arePrefixesPresent(
-                argMultimap, PREFIX_START_TIME, PREFIX_END_TIME)
+                argMultimap, PREFIX_START_TIME, PREFIX_END_TIME, PREFIX_DAY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindFreeTimeCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_TIME, PREFIX_END_TIME);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_TIME, PREFIX_END_TIME, PREFIX_DAY);
         Timing startTime = ParserUtil.parseTiming(argMultimap.getValue(PREFIX_START_TIME).get());
         Timing endTime = ParserUtil.parseTiming(argMultimap.getValue(PREFIX_END_TIME).get());
+        Day day = ParserUtil.parseDay((argMultimap.getValue(PREFIX_DAY)).get());
 
-        return new FindFreeTimeCommand(new IsFreePredicate(startTime, endTime));
+        return new FindFreeTimeCommand(new IsFreePredicate(startTime, endTime, day));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FindFreeTimeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Timing;
+import seedu.address.model.student.IsFreePredicate;
+
+import java.util.stream.Stream;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+
+/**
+ * Parses input arguments and creates a new FindFreeTimeCommand object
+ */
+public class FindFreeTimeCommandParser implements Parser<FindFreeTimeCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindFreeTimeCommand
+     * and returns an FindFreeTimeCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindFreeTimeCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(
+                        args, PREFIX_START_TIME, PREFIX_END_TIME);
+        if (!arePrefixesPresent(
+                argMultimap, PREFIX_START_TIME, PREFIX_END_TIME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindFreeTimeCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_TIME, PREFIX_END_TIME);
+        Timing startTime = ParserUtil.parseTiming(argMultimap.getValue(PREFIX_START_TIME).get());
+        Timing endTime = ParserUtil.parseTiming(argMultimap.getValue(PREFIX_END_TIME).get());
+
+        return new FindFreeTimeCommand(new IsFreePredicate(startTime, endTime));
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
@@ -1,15 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+
+import java.util.stream.Stream;
+
 import seedu.address.logic.commands.FindFreeTimeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Timing;
 import seedu.address.model.student.IsFreePredicate;
-
-import java.util.stream.Stream;
-
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 
 /**
  * Parses input arguments and creates a new FindFreeTimeCommand object

--- a/src/main/java/seedu/address/model/student/IsFreePredicate.java
+++ b/src/main/java/seedu/address/model/student/IsFreePredicate.java
@@ -36,8 +36,8 @@ public class IsFreePredicate implements Predicate<Student> {
                 )
                 .noneMatch(
                         moduleTiming ->
-                                startTime.compareTo(moduleTiming.getEndTime()) == -1
-                                && endTime.compareTo(moduleTiming.getStartTime()) == 1
+                                startTime.compareTo(moduleTiming.getEndTime()) < 0
+                                && endTime.compareTo(moduleTiming.getStartTime()) > 0
                 );
     }
 

--- a/src/main/java/seedu/address/model/student/IsFreePredicate.java
+++ b/src/main/java/seedu/address/model/student/IsFreePredicate.java
@@ -1,0 +1,52 @@
+package seedu.address.model.student;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.module.Timing;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Student} is free between a given timing
+ */
+public class IsFreePredicate implements Predicate<Student> {
+    private final Timing startTime, endTime;
+
+    public IsFreePredicate(Timing startTime, Timing endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return !student.getModuleTimings()
+                .stream()
+                .noneMatch(
+                        moduleTiming -> startTime.compareTo(moduleTiming.getEndTime()) == -1 && endTime.compareTo(moduleTiming.getStartTime()) == 1
+                );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof IsFreePredicate)) {
+            return false;
+        }
+
+        IsFreePredicate otherIsFreePredicate = (IsFreePredicate) other;
+        return startTime.equals(otherIsFreePredicate.startTime) && endTime.equals(otherIsFreePredicate.endTime);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("startTime", startTime)
+                .add("endTime", endTime)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/model/student/IsFreePredicate.java
+++ b/src/main/java/seedu/address/model/student/IsFreePredicate.java
@@ -1,18 +1,22 @@
 package seedu.address.model.student;
 
-import seedu.address.commons.util.StringUtil;
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.module.Timing;
-
-import java.util.List;
-import java.util.function.Predicate;
 
 /**
  * Tests that a {@code Student} is free between a given timing
  */
 public class IsFreePredicate implements Predicate<Student> {
-    private final Timing startTime, endTime;
+    private final Timing startTime;
+    private final Timing endTime;
 
+    /**
+     * Constructor to create a predicate
+     * @param startTime starting time of range
+     * @param endTime ending time of range
+     */
     public IsFreePredicate(Timing startTime, Timing endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
@@ -23,7 +27,9 @@ public class IsFreePredicate implements Predicate<Student> {
         return student.getModuleTimings()
                 .stream()
                 .noneMatch(
-                        moduleTiming -> startTime.compareTo(moduleTiming.getEndTime()) == -1 && endTime.compareTo(moduleTiming.getStartTime()) == 1
+                        moduleTiming ->
+                                startTime.compareTo(moduleTiming.getEndTime()) == -1
+                                && endTime.compareTo(moduleTiming.getStartTime()) == 1
                 );
     }
 

--- a/src/main/java/seedu/address/model/student/IsFreePredicate.java
+++ b/src/main/java/seedu/address/model/student/IsFreePredicate.java
@@ -20,7 +20,7 @@ public class IsFreePredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        return !student.getModuleTimings()
+        return student.getModuleTimings()
                 .stream()
                 .noneMatch(
                         moduleTiming -> startTime.compareTo(moduleTiming.getEndTime()) == -1 && endTime.compareTo(moduleTiming.getStartTime()) == 1

--- a/src/main/java/seedu/address/model/student/IsFreePredicate.java
+++ b/src/main/java/seedu/address/model/student/IsFreePredicate.java
@@ -3,6 +3,7 @@ package seedu.address.model.student;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.module.Day;
 import seedu.address.model.module.Timing;
 
 /**
@@ -12,20 +13,27 @@ public class IsFreePredicate implements Predicate<Student> {
     private final Timing startTime;
     private final Timing endTime;
 
+    private final Day day;
+
     /**
      * Constructor to create a predicate
      * @param startTime starting time of range
      * @param endTime ending time of range
+     * @param day day to check
      */
-    public IsFreePredicate(Timing startTime, Timing endTime) {
+    public IsFreePredicate(Timing startTime, Timing endTime, Day day) {
         this.startTime = startTime;
         this.endTime = endTime;
+        this.day = day;
     }
 
     @Override
     public boolean test(Student student) {
         return student.getModuleTimings()
                 .stream()
+                .filter(
+                        moduleTiming -> moduleTiming.getDay().equals(day)
+                )
                 .noneMatch(
                         moduleTiming ->
                                 startTime.compareTo(moduleTiming.getEndTime()) == -1
@@ -45,7 +53,9 @@ public class IsFreePredicate implements Predicate<Student> {
         }
 
         IsFreePredicate otherIsFreePredicate = (IsFreePredicate) other;
-        return startTime.equals(otherIsFreePredicate.startTime) && endTime.equals(otherIsFreePredicate.endTime);
+        return startTime.equals(otherIsFreePredicate.startTime)
+                && endTime.equals(otherIsFreePredicate.endTime)
+                && day.equals(otherIsFreePredicate.day);
     }
 
     @Override
@@ -53,6 +63,7 @@ public class IsFreePredicate implements Predicate<Student> {
         return new ToStringBuilder(this)
                 .add("startTime", startTime)
                 .add("endTime", endTime)
+                .add("day", day)
                 .toString();
     }
 }


### PR DESCRIPTION
This PR adds a `find_free_time` command that finds all students who do not have any module timings that clash with the specified timing.

Solves #45 

Example command

`find_free_time d/Wed st/1845 et/1900`