### PR TITLE
fix: Keep module state when editing students

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -146,7 +146,7 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
-        private List<ModuleCode> modules = new ArrayList<>();
+        private List<ModuleCode> modules;
 
         private List<ModuleTiming> moduleTimings = new ArrayList<>();
 
@@ -167,7 +167,7 @@ public class EditCommand extends Command {
         }
 
         public void setModules(List<ModuleCode> modules) {
-            this.modules = new ArrayList<>(modules);
+            this.modules = (modules != null) ? new ArrayList<>(modules) : null;
         }
 
         public void setModuleTimings(List<ModuleTiming> modules) {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -57,6 +57,9 @@ public class AddressBookParserTest {
     public void parseCommand_edit() throws Exception {
         Student student = new StudentBuilder().build();
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(student).build();
+        // (taufiq): I have to set this to null because we need to differentiate
+        // between presence/absence of module input
+        descriptor.setModules(null);
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_STUDENT.getOneBased() + " " + StudentUtil.getEditStudentDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_STUDENT, descriptor), command);


### PR DESCRIPTION
This addresses a bug (#61) pointed out by @blaukc where if we edit a student using the `edit` command and don't intend to change their modules, their module state gets completely wiped.

When we parse the `EditCommand` we create an `EditStudentDescriptor` instance which by default is initialized as a List with 0 entries.

So when executing the command we use the `getModules` function to decide if we want to keep the old module state or replace it with new module state. The bug was that the logic for the for `getModules` always returns a non-null `Optional` value (because it checks if `modules` is null which never happens bcos always initialised with empty list), thereby always taking the empty list of modules from the `EditStudentDescriptor` instance and not the old `Student` instance, thus wiping out the modules state.

This commit initializes `modules` as `null` so that `getModules` works as intended.