### PR TITLE
fix: add validation for find_free_time

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
@@ -10,7 +10,6 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.FindFreeTimeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Day;
-import seedu.address.model.module.ModuleTiming;
 import seedu.address.model.module.Timing;
 import seedu.address.model.student.IsFreePredicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindFreeTimeCommandParser.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.FindFreeTimeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Day;
+import seedu.address.model.module.ModuleTiming;
 import seedu.address.model.module.Timing;
 import seedu.address.model.student.IsFreePredicate;
 
@@ -39,7 +40,9 @@ public class FindFreeTimeCommandParser implements Parser<FindFreeTimeCommand> {
         Timing endTime = ParserUtil.parseTiming(argMultimap.getValue(PREFIX_END_TIME).get());
         Day day = ParserUtil.parseDay((argMultimap.getValue(PREFIX_DAY)).get());
 
-        return new FindFreeTimeCommand(new IsFreePredicate(startTime, endTime, day));
+        IsFreePredicate isFreePredicate = ParserUtil.parseIsFreePredicate(day, startTime, endTime);
+
+        return new FindFreeTimeCommand(isFreePredicate);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -15,7 +15,11 @@ import seedu.address.model.module.Day;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleTiming;
 import seedu.address.model.module.Timing;
-import seedu.address.model.student.*;
+import seedu.address.model.student.Address;
+import seedu.address.model.student.Email;
+import seedu.address.model.student.IsFreePredicate;
+import seedu.address.model.student.Name;
+import seedu.address.model.student.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -15,10 +15,7 @@ import seedu.address.model.module.Day;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleTiming;
 import seedu.address.model.module.Timing;
-import seedu.address.model.student.Address;
-import seedu.address.model.student.Email;
-import seedu.address.model.student.Name;
-import seedu.address.model.student.Phone;
+import seedu.address.model.student.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -207,5 +204,23 @@ public class ParserUtil {
             throw new ParseException(ModuleTiming.MESSAGE_CONSTRAINTS);
         }
         return new ModuleTiming(moduleCode, day, startTime, endTime);
+    }
+
+    /**
+     * Parses a {@code ModuleCode moduleCode}, {@code Day day}, {@code Timing startTime}, {@code Timing endTime}
+     * into an {@code ModuleTiming}.
+     * Also validates that start time < end time.
+     *
+     * @throws ParseException if the given {@code email} is invalid.
+     */
+    public static IsFreePredicate parseIsFreePredicate(
+            Day day, Timing startTime, Timing endTime) throws ParseException {
+        requireNonNull(day);
+        requireNonNull(startTime);
+        requireNonNull(endTime);
+        if (!IsFreePredicate.isValidTimeRange(startTime, endTime)) {
+            throw new ParseException(IsFreePredicate.MESSAGE_CONSTRAINTS);
+        }
+        return new IsFreePredicate(startTime, endTime, day);
     }
 }

--- a/src/main/java/seedu/address/model/student/IsFreePredicate.java
+++ b/src/main/java/seedu/address/model/student/IsFreePredicate.java
@@ -10,6 +10,7 @@ import seedu.address.model.module.Timing;
  * Tests that a {@code Student} is free between a given timing
  */
 public class IsFreePredicate implements Predicate<Student> {
+    public static final String MESSAGE_CONSTRAINTS = "End time should be larger than Start time";
     private final Timing startTime;
     private final Timing endTime;
 
@@ -26,6 +27,14 @@ public class IsFreePredicate implements Predicate<Student> {
         this.endTime = endTime;
         this.day = day;
     }
+
+    /**
+     * Returns true if the start time < end time.
+     */
+    public static boolean isValidTimeRange(Timing startTime, Timing endTime) {
+        return startTime.compareTo(endTime) < 0;
+    }
+
 
     @Override
     public boolean test(Student student) {


### PR DESCRIPTION
Added validation for start time < end time check for find_free_time

Validation can be added as setting a start time greater than end time will NOT result in no students being shown, which is an incorrect result (bug).

> Can be allowed only if the current behavior causes the software to misbehave (i.e., crash, give incorrect results, store inconsistent data, or make it unusable for typical users).

Closes: https://github.com/AY2324S2-CS2103T-W12-2/tp/issues/107, https://github.com/AY2324S2-CS2103T-W12-2/tp/issues/79
