### PR TITLE
fix: Remove text truncation for `list_modules`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/module/ListModulesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ListModulesCommand.java
@@ -38,7 +38,7 @@ public class ListModulesCommand extends Command {
         sb.append("List of modules with prefix: ").append(this.modulePrefix).append("\n");
         for (Module m : modules) {
             sb.append(m.getModuleCode().getCode()).append(" : ");
-            sb.append(StringUtil.truncate(m.getDescription().getValue(), 80)).append("\n");
+            sb.append(m.getDescription().getValue()).append("\n\n");
         }
         return new CommandResult(sb.toString());
     }

--- a/src/main/java/seedu/address/logic/commands/module/ListModulesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ListModulesCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 
 import java.util.List;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
-    xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true" />
 </StackPane>


### PR DESCRIPTION
Fixes #136

When calling `list_modues m/..`, the module description texts are truncated.

<img width="795" alt="image" src="https://github.com/AY2324S2-CS2103T-W12-2/tp/assets/7150533/e4be1446-52c3-4b75-a0eb-3c7a92c9492c">

This PR removes the truncation of 80 char that was set.

<img width="1552" alt="image" src="https://github.com/AY2324S2-CS2103T-W12-2/tp/assets/7150533/89cf7c8d-8c29-42e5-92cc-dcc6c4c0f98b">